### PR TITLE
修正: サイト名を「Hamaguriの謎解き保管庫」に変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Hamaguri謎解きポートフォリオ</title>
-    <meta name="description" content="Hamaguriが作成した謎解きのポートフォリオサイトです。ゲームや一枚謎を楽しめます。">
+    <title>Hamaguriの謎解き保管庫</title>
+    <meta name="description" content="Hamaguriの謎解き保管庫です。作成した謎解きゲームや一枚謎を楽しめます。">
     <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body>
     <header class="header">
         <nav class="nav">
             <h1 class="logo">
-                <a href="/">Hamaguri謎解き</a>
+                <a href="/">Hamaguriの謎解き保管庫</a>
             </h1>
         </nav>
     </header>

--- a/single-riddles/index.html
+++ b/single-riddles/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>一枚謎一覧 - Hamaguri謎解きポートフォリオ</title>
-    <meta name="description" content="Hamaguriが作成した一枚謎の一覧です。画像を見て謎を解いてみてください。">
+    <title>一枚謎一覧 - Hamaguriの謎解き保管庫</title>
+    <meta name="description" content="Hamaguriの謎解き保管庫の一枚謎一覧です。画像を見て謎を解いてみてください。">
     <link rel="stylesheet" href="../assets/css/style.css">
     <link rel="stylesheet" href="style.css">
 </head>
@@ -13,7 +13,7 @@
         <nav class="nav">
             <div class="container">
                 <h1 class="logo">
-                    <a href="../">Hamaguri謎解き</a>
+                    <a href="../">Hamaguriの謎解き保管庫</a>
                 </h1>
                 <nav class="breadcrumb">
                     <a href="../">TOP</a>

--- a/single-riddles/riddle.html
+++ b/single-riddles/riddle.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title id="pageTitle">謎詳細 - Hamaguri謎解きポートフォリオ</title>
-    <meta name="description" content="一枚謎の詳細ページです。画像を見て答えを考えてみてください。">
+    <title id="pageTitle">謎詳細 - Hamaguriの謎解き保管庫</title>
+    <meta name="description" content="Hamaguriの謎解き保管庫の一枚謎詳細ページです。画像を見て答えを考えてみてください。">
     <link rel="stylesheet" href="../assets/css/style.css">
     <link rel="stylesheet" href="style.css">
 </head>
@@ -13,7 +13,7 @@
         <nav class="nav">
             <div class="container">
                 <h1 class="logo">
-                    <a href="../">Hamaguri謎解き</a>
+                    <a href="../">Hamaguriの謎解き保管庫</a>
                 </h1>
                 <nav class="breadcrumb">
                     <a href="../">TOP</a>

--- a/single-riddles/script.js
+++ b/single-riddles/script.js
@@ -199,7 +199,7 @@ function displayRiddle(riddleId) {
     }
     
     // ページタイトルの更新
-    document.getElementById('pageTitle').textContent = `${riddle.title} - Hamaguri謎解きポートフォリオ`;
+    document.getElementById('pageTitle').textContent = `${riddle.title} - Hamaguriの謎解き保管庫`;
     document.getElementById('breadcrumbTitle').textContent = riddle.title;
     
     // 謎情報の表示


### PR DESCRIPTION
サイト全体のタイトルとブランディングを統一しました。

## 変更内容
- ヘッダーロゴ: 「Hamaguri謎解き」→「Hamaguriの謎解き保管庫」
- ページタイトル: 全ページで統一されたサイト名に更新
- meta description: サイト名に合わせて更新
- JavaScriptでの動的タイトル更新: 新サイト名に対応

## 修正ファイル
- index.html: メインページのタイトル・ロゴ・説明文
- single-riddles/index.html: 一覧ページのタイトル・ロゴ・説明文
- single-riddles/riddle.html: 詳細ページのタイトル・ロゴ・説明文
- single-riddles/script.js: 動的タイトル更新機能

より分かりやすく、魅力的なサイト名でブランディングを強化しました。

🤖 Generated with [Claude Code](https://claude.ai/code)