### PR TITLE
修正: Xシェアボタンのアイコンを復元

### DIFF
--- a/single-riddles/riddle.html
+++ b/single-riddles/riddle.html
@@ -126,6 +126,7 @@
                 </div>
                 <div class="modal-actions">
                     <button class="share-button" id="shareButton">
+                        <span class="share-icon">🐦</span>
                         Xでシェアする
                     </button>
                     <button class="close-modal-button" id="closeModalButton">


### PR DESCRIPTION
正解モーダルのXシェアボタンから欠落していた🐦アイコンを復元しました。

## 問題
- Xシェアボタンからspan要素のアイコン（🐦）が削除されていた
- ボタンの視覚的な識別性が低下していた

## 修正内容
- <span class="share-icon">🐦</span>を復元
- Xシェアボタンの見た目と機能を完全回復

## 影響
- 正解時のXシェア機能が正常に表示・動作するようになりました

🤖 Generated with [Claude Code](https://claude.ai/code)