### PR TITLE
3つの新しい謎解きカテゴリを追加

### DIFF
--- a/cluster-riddles/index.html
+++ b/cluster-riddles/index.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hamaguriのcluster謎まとめ</title>
+    <meta name="description" content="Hamaguriのcluster謎まとめです。謎を解いてください。">
+    <link rel="stylesheet" href="../assets/css/style.css">
+    <style>
+        /* cluster謎専用スタイル */
+        .breadcrumb {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 0.9rem;
+            color: #666;
+        }
+
+        .breadcrumb a {
+            color: #66BB88;
+            text-decoration: none;
+            transition: color 0.3s ease;
+        }
+
+        .breadcrumb a:hover {
+            color: #4A9966;
+        }
+
+        .separator {
+            color: #999;
+        }
+
+        .current {
+            color: #333;
+            font-weight: 500;
+        }
+
+        .coming-soon-section {
+            padding: 6rem 0;
+            text-align: center;
+            background: linear-gradient(135deg, #BBFFCC 0%, #88DDAA 100%);
+            color: #2c3e50;
+            margin-bottom: 3rem;
+        }
+
+        .coming-soon-content {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 0 20px;
+        }
+
+        .coming-soon-icon {
+            font-size: 6rem;
+            margin-bottom: 2rem;
+            opacity: 0.9;
+        }
+
+        .coming-soon-title {
+            font-size: 2.5rem;
+            margin-bottom: 1.5rem;
+            font-weight: bold;
+        }
+
+        .coming-soon-message {
+            font-size: 1.3rem;
+            margin-bottom: 2rem;
+            opacity: 0.95;
+            line-height: 1.8;
+        }
+
+        .coming-soon-details {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 12px;
+            padding: 2rem;
+            margin-top: 3rem;
+        }
+
+        /* レスポンシブデザイン */
+        @media (max-width: 768px) {
+            .coming-soon-icon {
+                font-size: 4rem;
+            }
+            
+            .coming-soon-title {
+                font-size: 2rem;
+            }
+            
+            .coming-soon-message {
+                font-size: 1.1rem;
+            }
+        }
+
+        @media (max-width: 480px) {
+            .coming-soon-section {
+                padding: 4rem 0;
+            }
+            
+            .coming-soon-details {
+                padding: 1.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <header class="header">
+        <nav class="nav">
+            <div class="container">
+                <h1 class="logo">
+                    <a href="../">Hamaguriの謎解き保管庫</a>
+                </h1>
+                <nav class="breadcrumb">
+                    <a href="../">TOP</a>
+                    <span class="separator">></span>
+                    <span class="current">cluster謎</span>
+                </nav>
+            </div>
+        </nav>
+    </header>
+
+    <main class="main">
+
+        <section class="coming-soon-section">
+            <div class="coming-soon-content">
+                <div class="coming-soon-icon">🏢</div>
+                <h2 class="coming-soon-title">cluster謎</h2>
+                <div class="coming-soon-details">
+                    <h3 style="margin-bottom: 1rem; font-size: 1.5rem;">開発予定</h3>
+                    <p style="font-size: 1.1rem; line-height: 1.8;">
+                        メタバース空間clusterで謎解きイベントを開催する気持ちがいつかは芽生えるかもしれません。<br>
+                        お楽しみに！
+                    </p>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <p class="copyright">
+                &copy; 2025 Hamaguri. All rights reserved.
+            </p>
+        </div>
+    </footer>
+
+    <script src="../assets/js/main.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -64,6 +64,42 @@
                             <span class="arrow">→</span>
                         </a>
                     </div>
+
+                    <div class="category-card">
+                        <div class="category-icon">💬</div>
+                        <h3 class="category-title">LINE謎</h3>
+                        <p class="category-description">
+                            LINEを使用した謎解きコンテンツをまとめています。
+                        </p>
+                        <a href="line-riddles/" class="category-link">
+                            LINE謎に挑戦
+                            <span class="arrow">→</span>
+                        </a>
+                    </div>
+
+                    <div class="category-card">
+                        <div class="category-icon">🏢</div>
+                        <h3 class="category-title">cluster謎</h3>
+                        <p class="category-description">
+                            メタバース空間clusterで開催した謎解きイベントをまとめています。
+                        </p>
+                        <a href="cluster-riddles/" class="category-link">
+                            cluster謎に挑戦
+                            <span class="arrow">→</span>
+                        </a>
+                    </div>
+
+                    <div class="category-card">
+                        <div class="category-icon">📁</div>
+                        <h3 class="category-title">制作実績</h3>
+                        <p class="category-description">
+                            これまでに制作した謎解き関連の作品や実績をまとめています。
+                        </p>
+                        <a href="portfolio/" class="category-link">
+                            制作実績を見る
+                            <span class="arrow">→</span>
+                        </a>
+                    </div>
                 </div>
             </div>
         </section>

--- a/line-riddles/index.html
+++ b/line-riddles/index.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>HamaguriのLINE謎まとめ</title>
+    <meta name="description" content="HamaguriのLINE謎まとめです。謎を解いてください。">
+    <link rel="stylesheet" href="../assets/css/style.css">
+    <style>
+        /* LINE謎専用スタイル */
+        .breadcrumb {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 0.9rem;
+            color: #666;
+        }
+
+        .breadcrumb a {
+            color: #66BB88;
+            text-decoration: none;
+            transition: color 0.3s ease;
+        }
+
+        .breadcrumb a:hover {
+            color: #4A9966;
+        }
+
+        .separator {
+            color: #999;
+        }
+
+        .current {
+            color: #333;
+            font-weight: 500;
+        }
+
+        .coming-soon-section {
+            padding: 6rem 0;
+            text-align: center;
+            background: linear-gradient(135deg, #BBFFCC 0%, #88DDAA 100%);
+            color: #2c3e50;
+            margin-bottom: 3rem;
+        }
+
+        .coming-soon-content {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 0 20px;
+        }
+
+        .coming-soon-icon {
+            font-size: 6rem;
+            margin-bottom: 2rem;
+            opacity: 0.9;
+        }
+
+        .coming-soon-title {
+            font-size: 2.5rem;
+            margin-bottom: 1.5rem;
+            font-weight: bold;
+        }
+
+        .coming-soon-message {
+            font-size: 1.3rem;
+            margin-bottom: 2rem;
+            opacity: 0.95;
+            line-height: 1.8;
+        }
+
+        .coming-soon-details {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 12px;
+            padding: 2rem;
+            margin-top: 3rem;
+        }
+
+        /* レスポンシブデザイン */
+        @media (max-width: 768px) {
+            .coming-soon-icon {
+                font-size: 4rem;
+            }
+            
+            .coming-soon-title {
+                font-size: 2rem;
+            }
+            
+            .coming-soon-message {
+                font-size: 1.1rem;
+            }
+        }
+
+        @media (max-width: 480px) {
+            .coming-soon-section {
+                padding: 4rem 0;
+            }
+            
+            .coming-soon-details {
+                padding: 1.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <header class="header">
+        <nav class="nav">
+            <div class="container">
+                <h1 class="logo">
+                    <a href="../">Hamaguriの謎解き保管庫</a>
+                </h1>
+                <nav class="breadcrumb">
+                    <a href="../">TOP</a>
+                    <span class="separator">></span>
+                    <span class="current">LINE謎</span>
+                </nav>
+            </div>
+        </nav>
+    </header>
+
+    <main class="main">
+
+        <section class="coming-soon-section">
+            <div class="coming-soon-content">
+                <div class="coming-soon-icon">💬</div>
+                <h2 class="coming-soon-title">LINE謎</h2>
+                <div class="coming-soon-details">
+                    <h3 style="margin-bottom: 1rem; font-size: 1.5rem;">開発予定</h3>
+                    <p style="font-size: 1.1rem; line-height: 1.8;">
+                        LINEを使った謎解きコンテンツを制作する気持ちがいつかは芽生えるかもしれません。<br>
+                        お楽しみに！
+                    </p>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <p class="copyright">
+                &copy; 2025 Hamaguri. All rights reserved.
+            </p>
+        </div>
+    </footer>
+
+    <script src="../assets/js/main.js"></script>
+</body>
+</html>

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hamaguriの制作実績</title>
+    <meta name="description" content="Hamaguriの制作実績をまとめています。">
+    <link rel="stylesheet" href="../assets/css/style.css">
+    <style>
+        /* 制作実績専用スタイル */
+        .breadcrumb {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 0.9rem;
+            color: #666;
+        }
+
+        .breadcrumb a {
+            color: #66BB88;
+            text-decoration: none;
+            transition: color 0.3s ease;
+        }
+
+        .breadcrumb a:hover {
+            color: #4A9966;
+        }
+
+        .separator {
+            color: #999;
+        }
+
+        .current {
+            color: #333;
+            font-weight: 500;
+        }
+
+        .coming-soon-section {
+            padding: 6rem 0;
+            text-align: center;
+            background: linear-gradient(135deg, #BBFFCC 0%, #88DDAA 100%);
+            color: #2c3e50;
+            margin-bottom: 3rem;
+        }
+
+        .coming-soon-content {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 0 20px;
+        }
+
+        .coming-soon-icon {
+            font-size: 6rem;
+            margin-bottom: 2rem;
+            opacity: 0.9;
+        }
+
+        .coming-soon-title {
+            font-size: 2.5rem;
+            margin-bottom: 1.5rem;
+            font-weight: bold;
+        }
+
+        .coming-soon-message {
+            font-size: 1.3rem;
+            margin-bottom: 2rem;
+            opacity: 0.95;
+            line-height: 1.8;
+        }
+
+        .coming-soon-details {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 12px;
+            padding: 2rem;
+            margin-top: 3rem;
+        }
+
+        /* レスポンシブデザイン */
+        @media (max-width: 768px) {
+            .coming-soon-icon {
+                font-size: 4rem;
+            }
+            
+            .coming-soon-title {
+                font-size: 2rem;
+            }
+            
+            .coming-soon-message {
+                font-size: 1.1rem;
+            }
+        }
+
+        @media (max-width: 480px) {
+            .coming-soon-section {
+                padding: 4rem 0;
+            }
+            
+            .coming-soon-details {
+                padding: 1.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <header class="header">
+        <nav class="nav">
+            <div class="container">
+                <h1 class="logo">
+                    <a href="../">Hamaguriの謎解き保管庫</a>
+                </h1>
+                <nav class="breadcrumb">
+                    <a href="../">TOP</a>
+                    <span class="separator">></span>
+                    <span class="current">制作実績</span>
+                </nav>
+            </div>
+        </nav>
+    </header>
+
+    <main class="main">
+
+        <section class="coming-soon-section">
+            <div class="coming-soon-content">
+                <div class="coming-soon-icon">📁</div>
+                <h2 class="coming-soon-title">制作実績</h2>
+                <div class="coming-soon-details">
+                    <h3 style="margin-bottom: 1rem; font-size: 1.5rem;">準備中</h3>
+                    <p style="font-size: 1.1rem; line-height: 1.8;">
+                        これまでの制作実績をまとめる気持ちがいつかは芽生えるかもしれません。<br>
+                        お楽しみに！
+                    </p>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <p class="copyright">
+                &copy; 2025 Hamaguri. All rights reserved.
+            </p>
+        </div>
+    </footer>
+
+    <script src="../assets/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
1. TOPページに新カテゴリを追加:
   - LINE謎 (💬) - LINEを使った謎解きコンテンツ
   - cluster謎 (🏢) - メタバース空間での謎解きイベント
   - 制作実績 (📁) - 謎解き関連作品・実績

2. 各カテゴリの開発中ページを作成:
   - line-riddles/index.html
   - cluster-riddles/index.html
   - portfolio/index.html

3. デザイン統一:
   - 緑系グラデーションとテーマカラーで統一
   - Web謎と同様の開発予定メッセージ
   - レスポンシブ対応

🤖 Generated with [Claude Code](https://claude.ai/code)